### PR TITLE
feat: respect PIXI_HOME for global skill discovery

### DIFF
--- a/pixi_skills/skill.py
+++ b/pixi_skills/skill.py
@@ -1,4 +1,5 @@
 import dataclasses
+import os
 import re
 import warnings
 from dataclasses import dataclass
@@ -116,10 +117,18 @@ def discover_local_skills(env: str) -> list[Skill]:
     return skills
 
 
+def _global_envs_dir() -> Path:
+    """Return the global pixi envs directory, respecting PIXI_HOME."""
+    pixi_home = os.environ.get("PIXI_HOME")
+    if pixi_home:
+        return Path(pixi_home) / "envs"
+    return Path.home() / ".pixi/envs"
+
+
 def discover_global_skills() -> list[Skill]:
-    """Discover global skills from ~/.pixi/envs/agent-skill-*/share/agent-skills/*."""
+    """Discover global skills from the global pixi envs directory."""
     skills = []
-    global_pixi = Path.home() / ".pixi/envs"
+    global_pixi = _global_envs_dir()
     if global_pixi.exists():
         for skill_dir in global_pixi.glob("agent-skill-*/share/agent-skills/*"):
             if skill_dir.is_dir() and (skill_dir / "SKILL.md").exists():

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -239,3 +239,16 @@ class TestDiscoverGlobalSkills:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         assert discover_global_skills() == []
+
+    def test_respects_pixi_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pixi_home = tmp_path / "custom-pixi"
+        skill_dir = pixi_home / "envs/agent-skill-foo/share/agent-skills/foo"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: foo\n---\n")
+        monkeypatch.setenv("PIXI_HOME", str(pixi_home))
+
+        skills = discover_global_skills()
+        assert len(skills) == 1
+        assert skills[0].name == "foo"

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -210,6 +210,10 @@ class TestDiscoverLocalSkills:
 
 
 class TestDiscoverGlobalSkills:
+    @pytest.fixture(autouse=True)
+    def _clear_pixi_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("PIXI_HOME", raising=False)
+
     def test_discovers_skills(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

- Add `_global_envs_dir()` helper that checks the `PIXI_HOME` environment variable to locate global pixi environments, falling back to `~/.pixi/envs` when unset.
- Update `discover_global_skills()` to use this helper instead of hardcoding `~/.pixi/envs`.
- Add test verifying `PIXI_HOME` is respected.

Extracted from #5.

## Test plan

- [x] All 86 tests pass
- [x] New `test_respects_pixi_home` test covers the behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global skills discovery now respects the PIXI_HOME environment variable for custom environment directories.

* **Bug Fixes**
  * Improved error handling during global skills discovery; invalid skill entries are now caught and warned instead of causing failures.

* **Tests**
  * Added tests ensuring global discovery respects PIXI_HOME and behaves reliably in a clean environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->