### PR TITLE
fix: encoding issues on windows

### DIFF
--- a/pixi_skills/skill.py
+++ b/pixi_skills/skill.py
@@ -71,7 +71,7 @@ def parse_skill_md(skill_md: Path) -> tuple[str | None, str]:
 
     Name is optional and can be derived from the directory name.
     """
-    content = skill_md.read_text()
+    content = skill_md.read_text(encoding="utf-8")
 
     # Check for YAML frontmatter
     if not content.startswith("---"):


### PR DESCRIPTION
If the skills contain special characters, the missing encoding caused issues on Windows where python tries to use the platforms encoding instead of uft-8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file encoding handling to ensure consistent behavior across different operating systems by explicitly specifying UTF-8 encoding when reading skill documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->