### PR TITLE
Change highlighting color

### DIFF
--- a/pixi_skills/selector.py
+++ b/pixi_skills/selector.py
@@ -9,7 +9,10 @@ CUSTOM_STYLE = Style(
         ("qmark", "fg:ansimagenta bold"),  # Diamond question mark
         ("question", "bold"),  # Question text
         ("pointer", "fg:ansimagenta bold"),  # Pointer arrow
-        ("highlighted", "noreverse fg:ansiwhite"),  # Currently highlighted - bright
+        (
+            "highlighted",
+            "fg:ansimagenta bold underline",
+        ),  # Currently highlighted - magenta text with underline
         ("selected", "noreverse"),  # Selected item - no text color change
         ("checkbox", "fg:ansigray"),  # Unselected checkbox
         ("checkbox-selected", "fg:ansigreen bold"),  # Selected checkbox (green)


### PR DESCRIPTION
The highlighting in manage is white, which makes it difficult to see what I am highlighting in light mode terminals. This PR makes it magenta.

Before:
<img width="1296" height="326" alt="image" src="https://github.com/user-attachments/assets/5d9a00a2-885d-4828-892e-d3eb97da2f4a" />

After:
<img width="1291" height="403" alt="image" src="https://github.com/user-attachments/assets/76df900e-d0ab-46b2-be71-5b93b10e9698" />
<img width="1396" height="222" alt="image" src="https://github.com/user-attachments/assets/aef829de-6f33-4f18-8828-8b84318e4f2a" />


